### PR TITLE
Update to API and APP

### DIFF
--- a/lair/api/Dockerfile
+++ b/lair/api/Dockerfile
@@ -1,10 +1,20 @@
-FROM alpine:latest
+FROM golang:1.8.1
 
 EXPOSE 11015
 
- RUN apk --update add curl && rm -fr /var/cache/apk/*
- RUN curl -Lo /usr/bin/api-server https://github.com/lair-framework/api-server/releases/download/v1.1.0/api-server_linux_amd64 \
-     && chmod +x /usr/bin/api-server
+RUN go get -v github.com/lair-framework/api-server
+ADD plugins /plugins
+WORKDIR /plugins
+RUN rm .keep
+RUN for file in *.go;                                         \
+        do                                                    \
+                echo "Making so for $file"  &&                \
+                so=$(echo $file | sed 's/\.go$/\.so/g') &&    \
+                go build -v -buildmode=plugin -o $so $file && \
+                rm $file ;                                    \
+        done
+WORKDIR /root
+ENV TRANSFORM_DIR=/plugins
 ENV MONGO_URL=mongodb://database:27017/lair
 ENV API_LISTENER=0.0.0.0:11015
-CMD /usr/bin/api-server
+CMD api-server

--- a/lair/app/Dockerfile
+++ b/lair/app/Dockerfile
@@ -1,15 +1,17 @@
-FROM node:0.10.41
+FROM node:latest
 
 WORKDIR /root/app
-
-RUN curl -SLO "https://github.com/lair-framework/lair/releases/download/v2.4.1/lair-v2.4.1-linux-amd64.tar.gz" \
-    && tar -zxf lair-v2.4.1-linux-amd64.tar.gz \
+RUN curl https://install.meteor.com/ | sh
+RUN curl -SLO "https://github.com/lair-framework/lair/releases/download/v2.5.0/lair-v2.5.0-linux-amd64.tar.gz" \
+    && tar -zxf lair-v2.5.0-linux-amd64.tar.gz \
     && cd bundle/programs/server \
     && npm i
+
+COPY ./package.json /root/app/bundle/programs/server/package.json
 
 ENV ROOT_URL=http://0.0.0.0
 ENV PORT 11014
 ENV MONGO_URL=mongodb://database:27017/lair
 ENV MONGO_OPLOG_URL=mongodb://database:27017/local
 EXPOSE 11014
-CMD node /root/app/bundle/main.js
+CMD cd /root/app/bundle/programs/server && meteor npm start

--- a/lair/app/package.json
+++ b/lair/app/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "meteor-dev-bundle",
+  "version": "0.0.0",
+  "dependencies": {
+    "meteor-promise": "0.8.0",
+    "fibers": "1.0.15",
+    "promise": "7.1.1",
+    "underscore": "1.5.2",
+    "source-map-support": "https://github.com/meteor/node-source-map-support/tarball/1912478769d76e5df4c365e147f25896aee6375e",
+    "semver": "4.1.0",
+    "node-gyp": "3.4.0",
+    "node-pre-gyp": "0.6.29"
+  },
+  "devDependencies": {
+    "eachline": "https://github.com/meteor/node-eachline/tarball/ff89722ff94e6b6a08652bf5f44c8fffea8a21da",
+    "chalk": "0.5.1"
+  },
+  "scripts": {
+    "install": "node npm-rebuild.js",
+    "start": "node /root/app/bundle/main.js"
+  }
+}


### PR DESCRIPTION
APP: An issue caused docker to use 100% of one core. We have switched to
meteor to fix this issue.

API: Updated to add the ability to use plugins with go 1.8. However, in
order to use plugins the main app and plugins need to be compiled on the
same host. We now use golang:1.8.1 image and build the api-server and
any plugin in the plugins directory.